### PR TITLE
feat: add example validator panel

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Esta extensión de Visual Studio Code analiza código Python en tiempo real y ut
 
 - **Escucha en vivo**: [`listener/liveEditorListener`](src/listener/liveEditorListener.ts) observa los cambios en el editor y solicita sugerencias al servicio para mostrarlas como diagnósticos y decoraciones en la línea.
 - **Autocompletado**: el mismo módulo registra un proveedor de completado que inserta sugerencias de la IA cuando se escribe `.`.
+- **Ventana de validación**: comando `Abrir Validador de Ejemplos` abre un panel donde se puede pegar código y obtener una validación del modelo.
 - **Cliente de API**: [`deepseek/client`](src/deepseek/client.ts) envía el código al endpoint `https://api.moonshot.ai/v1/chat/completions` usando la variable de entorno `KIMI_API_KEY`.
 - **Registro de eventos**: [`utils/logger`](src/utils/logger.ts) añade un prefijo uniforme a los mensajes de consola.
 
@@ -21,6 +22,7 @@ Esta extensión de Visual Studio Code analiza código Python en tiempo real y ut
 2. Compila la extensión: `npm run compile`.
 3. Presiona `F5` en VS Code para abrir una ventana de desarrollo con la extensión.
 4. Abre un archivo Python y comienza a escribir; aparecerán diagnósticos y sugerencias de completado.
+5. Ejecuta el comando **Abrir Validador de Ejemplos** para probar fragmentos de código en una ventana dedicada.
 
 ## Estructura del código
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "Other"
   ],
   "activationEvents": [
-    "onLanguage:python"
+    "onLanguage:python",
+    "onCommand:ai-mechanic.openExampleValidator"
   ],
   "main": "./dist/extension.js",
   "contributes": {
@@ -18,6 +19,10 @@
       {
         "command": "ai-mechanic.helloWorld",
         "title": "Hello World"
+      },
+      {
+        "command": "ai-mechanic.openExampleValidator",
+        "title": "Abrir Validador de Ejemplos"
       }
     ]
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,11 +1,18 @@
 import * as vscode from 'vscode';
 import { startLiveListener, registerCompletionProvider } from './listener/liveEditorListener';
+import { openExamplePanel } from './panel/examplePanel';
 
 export function activate(context: vscode.ExtensionContext) {
   console.log('AI Helper activado');
 
   startLiveListener(context);
   registerCompletionProvider(context);
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('ai-mechanic.openExampleValidator', () =>
+      openExamplePanel(context)
+    )
+  );
 
   vscode.window.showInformationMessage('AI Helper listo con DeepSeek!');
 }

--- a/src/panel/examplePanel.ts
+++ b/src/panel/examplePanel.ts
@@ -1,0 +1,59 @@
+import * as vscode from 'vscode';
+import { getSuggestions } from '../deepseek/client';
+
+export function openExamplePanel(context: vscode.ExtensionContext) {
+  const panel = vscode.window.createWebviewPanel(
+    'exampleValidator',
+    'Validador de Ejemplos',
+    vscode.ViewColumn.One,
+    {
+      enableScripts: true
+    }
+  );
+
+  panel.webview.html = getWebviewContent();
+
+  panel.webview.onDidReceiveMessage(async (message) => {
+    if (message.command === 'validate') {
+      const suggestions = await getSuggestions(message.code);
+      panel.webview.postMessage({ command: 'result', suggestions });
+    }
+  });
+
+  context.subscriptions.push(panel);
+}
+
+function getWebviewContent(): string {
+  return `<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <style>
+    body { font-family: sans-serif; margin: 0 20px; }
+    textarea { width: 100%; height: 200px; }
+    button { margin-top: 10px; }
+    pre { background: #f3f3f3; padding: 10px; }
+  </style>
+</head>
+<body>
+  <h2>Escribe tu ejemplo de código</h2>
+  <textarea id="code"></textarea>
+  <br/>
+  <button id="validate">Validar</button>
+  <pre id="result"></pre>
+  <script>
+    const vscode = acquireVsCodeApi();
+    document.getElementById('validate').addEventListener('click', () => {
+      const code = (document.getElementById('code')).value;
+      vscode.postMessage({ command: 'validate', code });
+    });
+    window.addEventListener('message', event => {
+      const message = event.data;
+      if (message.command === 'result') {
+        document.getElementById('result').textContent = message.suggestions.join('\n');
+      }
+    });
+  </script>
+</body>
+</html>`;
+}


### PR DESCRIPTION
## Summary
- add webview panel to validate code snippets with AI
- expose command `Abrir Validador de Ejemplos` and document its usage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689c08d85fc48330b69776310b2e7fa2