### PR TITLE
feat: add interactive chat panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+out/
+src/**/*.js
+src/**/*.js.map

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "Other"
   ],
   "activationEvents": [
-    "onLanguage:python"
+    "onLanguage:python",
+    "onCommand:ai-mechanic.openChat"
   ],
   "main": "./dist/extension.js",
   "contributes": {
@@ -22,6 +23,10 @@
       {
         "command": "ai-mechanic.openExampleValidator",
         "title": "Abrir Validador de Ejemplos"
+      },
+      {
+        "command": "ai-mechanic.openChat",
+        "title": "Abrir Chat AI"
       }
     ],
     "viewsContainers": {
@@ -54,7 +59,6 @@
     "lint": "eslint src",
     "test": "mocha out/test/simpleApi.test.js"
   },
-  
   "devDependencies": {
     "@types/axios": "^0.9.36",
     "@types/chai": "^5.2.2",

--- a/src/deepseek/client.ts
+++ b/src/deepseek/client.ts
@@ -66,6 +66,12 @@ export async function getSuggestions(code: string): Promise<string[]> {
   return [response];
 }
 
+export type ChatMessage = Message;
+export async function chat(messages: ChatMessage[]): Promise<string> {
+  return callApi(messages);
+}
+
+
 const lessonCache: Record<LessonLevel, string> = {
   principiante: `Bienvenido al nivel principiante.
 1. Repasa la sintaxis básica de Python.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { startLiveListener, registerCompletionProvider } from './listener/liveEditorListener';
 import { openExamplePanel } from './panel/examplePanel';
+import { openChatPanel } from './panel/chatPanel';
 import { TutorViewProvider } from './panel/tutorView';
 
 
@@ -18,6 +19,11 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand('ai-mechanic.openExampleValidator', () =>
       openExamplePanel(context)
+    )
+  );
+  context.subscriptions.push(
+    vscode.commands.registerCommand('ai-mechanic.openChat', () =>
+      openChatPanel(context)
     )
   );
 

--- a/src/panel/chatPanel.ts
+++ b/src/panel/chatPanel.ts
@@ -1,0 +1,80 @@
+import * as vscode from 'vscode';
+import { chat, ChatMessage } from '../deepseek/client';
+
+export function openChatPanel(context: vscode.ExtensionContext) {
+  const panel = vscode.window.createWebviewPanel(
+    'aiChat',
+    'Chat AI',
+    vscode.ViewColumn.One,
+    { enableScripts: true }
+  );
+
+  panel.webview.html = getWebviewContent();
+
+  const conversation: ChatMessage[] = [];
+
+  panel.webview.onDidReceiveMessage(async (message) => {
+    if (message.command === 'sendMessage') {
+      conversation.push({ role: 'user', content: message.text });
+      const reply = await chat(conversation);
+      conversation.push({ role: 'assistant', content: reply });
+      panel.webview.postMessage({ command: 'addMessage', who: 'assistant', text: reply });
+    }
+  });
+
+  context.subscriptions.push(panel);
+}
+
+function getWebviewContent(): string {
+  return `<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <style>
+    body { font-family: sans-serif; margin: 0; padding: 10px; }
+    #messages { border: 1px solid #ccc; height: 300px; overflow-y: auto; padding: 5px; }
+    .message { margin: 5px 0; }
+    .user { text-align: right; color: blue; }
+    .assistant { text-align: left; color: green; }
+    #input { display: flex; margin-top: 10px; }
+    #input input { flex: 1; }
+  </style>
+</head>
+<body>
+  <h3>Chat con AI</h3>
+  <div id="messages"></div>
+  <div id="input">
+    <input id="text" type="text" placeholder="Escribe un mensaje" />
+    <button id="send">Enviar</button>
+  </div>
+  <script>
+    const vscode = acquireVsCodeApi();
+    const messagesDiv = document.getElementById('messages');
+
+    document.getElementById('send').addEventListener('click', () => {
+      const input = document.getElementById('text');
+      const text = input.value;
+      if (!text) { return; }
+      appendMessage('user', text);
+      vscode.postMessage({ command: 'sendMessage', text });
+      input.value = '';
+    });
+
+    window.addEventListener('message', event => {
+      const message = event.data;
+      if (message.command === 'addMessage') {
+        appendMessage(message.who, message.text);
+      }
+    });
+
+    function appendMessage(who, text) {
+      const div = document.createElement('div');
+      div.className = 'message ' + who;
+      div.textContent = text;
+      messagesDiv.appendChild(div);
+      messagesDiv.scrollTop = messagesDiv.scrollHeight;
+    }
+  </script>
+</body>
+</html>`;
+}


### PR DESCRIPTION
## Summary
- add chat panel webview enabling interactive AI requests
- expose chat API and register new command to open the panel
- ignore build artifacts

## Testing
- `npm run compile` *(fails: sh: 1: webpack: Permission denied)*
- `npm test` *(fails: TS2688: Cannot find type definition file for 'eslint'/'node')*

------
https://chatgpt.com/codex/tasks/task_e_689dd67645d483309dfb693910ed0d89