### PR TITLE
feat: integrate chat into tutor panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+out/
+src/**/*.js
+src/**/*.js.map

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "lint": "eslint src",
     "test": "mocha out/test/simpleApi.test.js"
   },
-  
   "devDependencies": {
     "@types/axios": "^0.9.36",
     "@types/chai": "^5.2.2",

--- a/src/deepseek/client.ts
+++ b/src/deepseek/client.ts
@@ -66,6 +66,12 @@ export async function getSuggestions(code: string): Promise<string[]> {
   return [response];
 }
 
+export type ChatMessage = Message;
+export async function chat(messages: ChatMessage[]): Promise<string> {
+  return callApi(messages);
+}
+
+
 const lessonCache: Record<LessonLevel, string> = {
   principiante: `Bienvenido al nivel principiante.
 1. Repasa la sintaxis básica de Python.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,7 +20,6 @@ export function activate(context: vscode.ExtensionContext) {
       openExamplePanel(context)
     )
   );
-
   vscode.window.showInformationMessage('AI Helper listo con DeepSeek!');
 }
 

--- a/src/panel/tutorView.ts
+++ b/src/panel/tutorView.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { getLesson } from '../deepseek/client';
+import { getLesson, chat, ChatMessage } from '../deepseek/client';
 
 export class TutorViewProvider implements vscode.WebviewViewProvider {
   public static readonly viewType = 'ai-mechanic.tutorView';
@@ -10,10 +10,27 @@ export class TutorViewProvider implements vscode.WebviewViewProvider {
     webviewView.webview.options = { enableScripts: true };
     webviewView.webview.html = this.getHtml();
 
+    const conversation: ChatMessage[] = [];
+
     webviewView.webview.onDidReceiveMessage(async (message) => {
       if (message.command === 'chooseLevel') {
+        conversation.length = 0;
         const content = await getLesson(message.level);
-        webviewView.webview.postMessage({ command: 'showLesson', content });
+        conversation.push({ role: 'assistant', content });
+        webviewView.webview.postMessage({
+          command: 'addMessage',
+          who: 'assistant',
+          text: content,
+        });
+      } else if (message.command === 'sendMessage') {
+        conversation.push({ role: 'user', content: message.text });
+        const reply = await chat(conversation);
+        conversation.push({ role: 'assistant', content: reply });
+        webviewView.webview.postMessage({
+          command: 'addMessage',
+          who: 'assistant',
+          text: reply,
+        });
       }
     });
   }
@@ -24,9 +41,14 @@ export class TutorViewProvider implements vscode.WebviewViewProvider {
 <head>
   <meta charset="UTF-8">
   <style>
-    body { font-family: sans-serif; padding: 10px; }
+    body { font-family: sans-serif; padding: 10px; display: flex; flex-direction: column; height: 100%; }
     button { margin-right: 8px; }
-    #content { white-space: pre-wrap; margin-top: 10px; }
+    #messages { flex: 1; border: 1px solid #ccc; overflow-y: auto; padding: 5px; }
+    .message { margin: 5px 0; }
+    .user { text-align: right; color: blue; }
+    .assistant { text-align: left; color: green; }
+    #input { display: flex; margin-top: 10px; }
+    #input input { flex: 1; }
   </style>
 </head>
 <body>
@@ -36,7 +58,11 @@ export class TutorViewProvider implements vscode.WebviewViewProvider {
     <button id="beginner">Principiante</button>
     <button id="intermediate">Intermedio</button>
   </div>
-  <div id="content"></div>
+  <div id="messages"></div>
+  <div id="input">
+    <input id="text" type="text" placeholder="Escribe un mensaje" />
+    <button id="send">Enviar</button>
+  </div>
   <script>
     const vscode = acquireVsCodeApi();
     document.getElementById('beginner').addEventListener('click', () => {
@@ -45,12 +71,32 @@ export class TutorViewProvider implements vscode.WebviewViewProvider {
     document.getElementById('intermediate').addEventListener('click', () => {
       vscode.postMessage({ command: 'chooseLevel', level: 'intermedio' });
     });
+    document.getElementById('send').addEventListener('click', sendMessage);
+    document.getElementById('text').addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') { sendMessage(); }
+    });
+    const messagesDiv = document.getElementById('messages');
     window.addEventListener('message', event => {
       const message = event.data;
-      if (message.command === 'showLesson') {
-        document.getElementById('content').textContent = message.content;
+      if (message.command === 'addMessage') {
+        appendMessage(message.who, message.text);
       }
     });
+    function sendMessage() {
+      const input = document.getElementById('text');
+      const text = input.value;
+      if (!text) { return; }
+      appendMessage('user', text);
+      vscode.postMessage({ command: 'sendMessage', text });
+      input.value = '';
+    }
+    function appendMessage(who, text) {
+      const div = document.createElement('div');
+      div.className = 'message ' + who;
+      div.textContent = text;
+      messagesDiv.appendChild(div);
+      messagesDiv.scrollTop = messagesDiv.scrollHeight;
+    }
   </script>
 </body>
 </html>`;


### PR DESCRIPTION
## Summary
- integrate chat UI into existing tutor panel for level and suggestions
- streamline extension by removing separate chat command and panel

## Testing
- `npm run compile` *(fails: sh: 1: webpack: Permission denied)*
- `npm test` *(fails: sh: 1: webpack: Permission denied)*

------
https://chatgpt.com/codex/tasks/task_e_689dd67645d483309dfb693910ed0d89