### PR TITLE
refactor: simplificar manejo de errores en chat

### DIFF
--- a/src/deepseek/client.ts
+++ b/src/deepseek/client.ts
@@ -319,10 +319,7 @@ export async function chat(messages: ChatMessage[]): Promise<string> {
 
   } catch (error) {
     console.error('Error en chat:', error);
-    return JSON.stringify({
-      type: 'error',
-      content: `Error en el chat: ${(error as Error).message}`
-    });
+    return `Error en el chat: ${(error as Error).message}`;
   }
 }
 


### PR DESCRIPTION
## Summary
- simplificar manejo de errores en chat devolviendo texto plano
- confirmar que parseAIResponse ya trata entradas no JSON como texto

## Testing
- `npm test` *(falla: src/views/TutorViewProvider.ts(33,17): Type 'string' is not assignable to type 'AIResponse')*


------
https://chatgpt.com/codex/tasks/task_e_68a7d2e87efc8330bebc5e49803f0e3c