### PR TITLE
Format JSON messages in chat panel webview

### DIFF
--- a/src/panel/chatPanel.ts
+++ b/src/panel/chatPanel.ts
@@ -264,10 +264,21 @@ function getWebviewContent(): string {
       }
     });
 
+    function formatContent(text) {
+      try {
+        const parsed = JSON.parse(text);
+        const pre = document.createElement('pre');
+        pre.textContent = JSON.stringify(parsed, null, 2);
+        return pre;
+      } catch {
+        return document.createTextNode(text);
+      }
+    }
+
     function appendMessage(who, text, isProcessing = false) {
       const container = document.createElement('div');
       container.className = 'message ' + who + (isProcessing ? ' processing' : '');
-      container.textContent = text;
+      container.appendChild(formatContent(text));
       messagesDiv.appendChild(container);
       messagesDiv.scrollTop = messagesDiv.scrollHeight;
     }
@@ -277,7 +288,8 @@ function getWebviewContent(): string {
       const lastMessage = messages[messages.length - 1];
 
       if (lastMessage) {
-        lastMessage.textContent = text;
+        lastMessage.innerHTML = '';
+        lastMessage.appendChild(formatContent(text));
         lastMessage.className = 'message ' + who; // Remover clase 'processing'
         messagesDiv.scrollTop = messagesDiv.scrollHeight;
       } else {


### PR DESCRIPTION
## Summary
- Parse incoming strings as JSON when possible and render formatted content in the chat webview
- Ensure messages replace raw JSON strings with readable, pretty-printed text

## Testing
- `npm test` *(fails: TypeScript compile errors in TutorViewProvider.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68a7d512fae88330b02bafc07ddc9a23