### PR TITLE
Strip markdown in chat panel messages

### DIFF
--- a/media/format.js
+++ b/media/format.js
@@ -1,3 +1,19 @@
+function removeMarkdown(text) {
+  return text
+    .replace(/```[\s\S]*?```/g, '')
+    .replace(/`([^`]*)`/g, '$1')
+    .replace(/!\[[^\]]*\]\([^\)]*\)/g, '')
+    .replace(/\[([^\]]*)\]\([^\)]*\)/g, '$1')
+    .replace(/^#{1,6}\s+/gm, '')
+    .replace(/^>\s+/gm, '')
+    .replace(/[*_]{1,3}([^*_]+)[*_]{1,3}/g, '$1')
+    .replace(/~~([^~]+)~~/g, '$1')
+    .replace(/^\s*[-+*]\s+/gm, '')
+    .replace(/^\s*\d+\.\s+/gm, '')
+    .replace(/[*_`~]/g, '')
+    .trim();
+}
+
 function formatMessage(text) {
   const regex = /```([\s\S]*?)```/g;
   const parts = [];
@@ -5,13 +21,21 @@ function formatMessage(text) {
   let match;
   while ((match = regex.exec(text)) !== null) {
     if (match.index > lastIndex) {
-      parts.push({ type: 'text', content: text.slice(lastIndex, match.index).trim() });
+      const segment = text.slice(lastIndex, match.index).trim();
+      const cleaned = removeMarkdown(segment);
+      if (cleaned) {
+        parts.push({ type: 'text', content: cleaned });
+      }
     }
     parts.push({ type: 'code', content: match[1].trim() });
     lastIndex = match.index + match[0].length;
   }
   if (lastIndex < text.length) {
-    parts.push({ type: 'text', content: text.slice(lastIndex).trim() });
+    const segment = text.slice(lastIndex).trim();
+    const cleaned = removeMarkdown(segment);
+    if (cleaned) {
+      parts.push({ type: 'text', content: cleaned });
+    }
   }
   return parts;
 }

--- a/src/panel/chatPanel.ts
+++ b/src/panel/chatPanel.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { chat, ChatMessage, setApiKey, hasApiKey } from '../deepseek/client';
+import { removeMarkdown } from '../utils/removeMarkdown';
 
 // Tipos y funciones auxiliares para análisis académico (stub temporal)
 type AcademicReport = any;
@@ -52,7 +53,7 @@ export async function openChatPanel(context: vscode.ExtensionContext) {
           panel.webview.postMessage({
             command: 'replaceLastMessage',
             who: 'assistant',
-            text: reply
+            text: removeMarkdown(reply)
           });
           return;
         }
@@ -63,7 +64,7 @@ export async function openChatPanel(context: vscode.ExtensionContext) {
         panel.webview.postMessage({
           command: 'replaceLastMessage',
           who: 'assistant',
-          text: reply
+          text: removeMarkdown(reply)
         });
 
       } catch (error) {

--- a/src/utils/removeMarkdown.ts
+++ b/src/utils/removeMarkdown.ts
@@ -1,0 +1,29 @@
+export function removeMarkdown(text: string): string {
+  if (!text) {
+    return '';
+  }
+  return text
+    // Remove fenced code blocks
+    .replace(/```[\s\S]*?```/g, '')
+    // Remove inline code
+    .replace(/`([^`]*)`/g, '$1')
+    // Remove images
+    .replace(/!\[[^\]]*\]\([^\)]*\)/g, '')
+    // Remove links but keep text
+    .replace(/\[([^\]]*)\]\([^\)]*\)/g, '$1')
+    // Remove headings
+    .replace(/^#{1,6}\s+/gm, '')
+    // Remove blockquotes
+    .replace(/^>\s+/gm, '')
+    // Remove emphasis and strong
+    .replace(/[*_]{1,3}([^*_]+)[*_]{1,3}/g, '$1')
+    // Remove strikethrough
+    .replace(/~~([^~]+)~~/g, '$1')
+    // Remove unordered list markers
+    .replace(/^\s*[-+*]\s+/gm, '')
+    // Remove ordered list numbers
+    .replace(/^\s*\d+\.\s+/gm, '')
+    // Trim remaining markdown characters
+    .replace(/[*_`~]/g, '')
+    .trim();
+}


### PR DESCRIPTION
## Summary
- add utility to remove markdown syntax
- clean assistant replies in chat panel
- sanitize formatted messages in webview

## Testing
- `npm test` *(fails: Type 'string' is not assignable to type 'AIResponse', TutorViewProvider.ts:33)*

------
https://chatgpt.com/codex/tasks/task_e_68a7dbb2f5688330bb20abbdc08413c8